### PR TITLE
fix email link and tudev dead link

### DIFF
--- a/public/pages/index.html
+++ b/public/pages/index.html
@@ -122,7 +122,7 @@
                     <div class="qa">
                         <div class="question">Who do I talk to if I have any questions?</div>
                         <div class="answer">
-                            If you have any questions or comments at all, don't hesistate to send an email to <bold>team@owlhacks.com</bold>.
+                            If you have any questions or comments at all, don't hesistate to send an email to <bold><a href="mailto:team@owlhacks.com">team@owlhacks.com</a></bold>.
                         </div>
                     </div>
                     <div class="qa">
@@ -179,7 +179,7 @@
 
         </section>
         <footer>
-            <span>Made with</span> <span class="glyphicon glyphicon-heart"></span> <span>by</span> <a href="http://tudev.org" id="tudev-icon"></a> <span>in Philadelphia</span>
+            <span>Made with</span> <span class="glyphicon glyphicon-heart"></span> <span>by</span> <span id="tudev-icon"></span> <span>in Philadelphia</span>
         </footer>
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Make team@owlhacks.com a link in the FAQ, update TUDev icon at the bottom to not link to a dead site.
