### PR TITLE
Fixed High Resolution Scaling

### DIFF
--- a/public/less/conduct.less
+++ b/public/less/conduct.less
@@ -13,6 +13,8 @@ html {
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
+      height: 100%;
+      overflow: auto;
       
       @media (max-width: @iphone6plus-width) {
           padding: 30px 30px;
@@ -23,7 +25,7 @@ html {
         }
 
       #container {
-
+        
         #plsnocrime {
           margin-bottom: 30px;
           background: white;
@@ -34,6 +36,10 @@ html {
           
           @media (max-width: @iphone6plus-width) {
             padding: 20px 20px;
+          }
+          
+          @media (min-width: 1500px) {
+            padding: 50px 50px; 
           }
 
           h1 {
@@ -47,6 +53,10 @@ html {
             @media (max-width: @iphone6plus-width) {
               font-size: 24px;
             }
+            
+            @media (min-width: 1500px) {
+              font-size: 42px; 
+            }
           }
 
           p {
@@ -59,6 +69,10 @@ html {
             
             @media (max-width: @iphone6plus-width) {
               font-size: 16px;
+            }
+            
+            @media (min-width: 1500px) {
+              font-size: 28px; 
             }
           }
 

--- a/public/less/conduct.less
+++ b/public/less/conduct.less
@@ -1,11 +1,11 @@
 html {
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   margin: 0;
   
   body {
     width: 100%;
-    height: 100%;
+    min-height: 100%;
     margin: 0;
     
     #conduct{
@@ -13,7 +13,7 @@ html {
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
-      height: 100%;
+      min-height: 100%;
       overflow: auto;
       
       @media (max-width: @iphone6plus-width) {


### PR DESCRIPTION
## Feature

Conduct Page
## What I Fixed

At a  pixel width of 1500 or above the section containing the trianglify svg image would no long cover body.  To fix this I simply set the height to 100% with overflow auto.  I also increased various font sizes to make it more readable at specific screen width break points.
## Where to begin testing

I suggest testing first on high resolution to confirm that the changes actually work in all cases.  I also suggest follow-up testing on low resolution mobile devices to see if that responsiveness was effected in any way.  I've already tested both cases, but I could of very easily made another mistake.
